### PR TITLE
Forward the original client IP to the stats worker

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -58,6 +58,7 @@ async function handleEvent(event) {
     const statsRequest = new Request(event.request);
     // Offload stats from the main thread
     statsRequest.headers.set("X-Original-Url", url);
+    statsRequest.headers.set("X-Original-Ip", request.headers.get('cf-connecting-ip'));
     event.waitUntil(fetch("https://dashflare.mre.workers.dev", statsRequest));
 
     return response;


### PR DESCRIPTION
Sets a new `x-original-ip` header in the forwarded request to the stats worker with the value of the original client IP taken from the `cf-connecting-ip` header.

For this to work it also needs a redeployment of the stats worker which includes https://github.com/jorgelbg/dashflare/issues/9.
