### PR TITLE
fix UB in FFI example

### DIFF
--- a/content/2023/cursed-rust/index.md
+++ b/content/2023/cursed-rust/index.md
@@ -171,12 +171,21 @@ and for which you don't want to come up with a name.
 ```rust
 extern crate libc;
 use libc::{c_char, c_int};
+use core::ffi::CStr;
 
 extern "C" {
     fn printf(fmt: *const c_char, ...) -> c_int;
 }
-unsafe {
-    printf("hello\n".as_ptr() as *const i8);
+
+fn main() {
+    const HI: &CStr = match CStr::from_bytes_until_nul(b"hello\n\0") {
+        Ok(x) => x,
+        Err(_) => panic!(),
+    };
+
+    unsafe {
+        printf(HI.as_ptr());
+    }
 }
 ```
 
@@ -185,7 +194,7 @@ example shows how to call the C standard library's `printf` function from Rust.
 It's unsafe because we are using a raw pointer to pass the string to the
 function. This teaches us a little bit about how FFI works in Rust.
 
-Credit goes to [/u/pinespear on Reddit](https://www.reddit.com/r/rustjerk/comments/16xty71/s_str_print_shello/k36n6be/).
+Credit goes to [/u/pinespear on Reddit](https://www.reddit.com/r/rustjerk/comments/16xty71/s_str_print_shello/k36n6be/) and [@brk@infosec.exchange](https://infosec.exchange/@brk).
 
 ## Solution 8: C++ Style
 


### PR DESCRIPTION
C strings must be nul terminated

---

I also didn't want to introduce what could look like the possibility of runtime panic by using unwrap, so I forced the string to be checked at compile time, which means we have to use `panic!()` and not `Result.unwrap()` and that made it quite verbose haha