### PR TITLE
Proposing a Fix for Mobile Styles

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -55,9 +55,6 @@ header {
   font-size: 0.8em;
   text-align: center;
   padding-top: 25px;
-  /* position: sticky; */
-  top: 50px;
-  height: 100vh;
 }
 
 .logo {
@@ -432,13 +429,6 @@ summary {
 
 /* Styles for small screens */
 @media (max-width: 920px) {
-  header {
-    position: static;
-    width: auto;
-    height: auto;
-    margin: 0 auto;
-  }
-
   .navwrapper {
     margin: 0 auto;
     display: flex;
@@ -446,10 +436,12 @@ summary {
 
   .container {
     margin: 0 auto;
+    flex-direction: column;
+    align-items: center;
   }
 
   main {
-    padding: 0px 10px;
+    padding: 0px 20px;
   }
 
   .searchicon {


### PR DESCRIPTION
First let me say I've enjoyed the blog so far! I just read [this article](https://endler.dev/2025/best-programmers/) and liked it. I was about to share it with my friends, but then I noticed the body text was squished to the right, making it hard to read on mobile. I made some quick CSS tweaks to put the header above the page content using your existing mobile breakpoint. I know styling can be very subjective, so feel free to ignore or close this. I won't be offended. I would also recommend checking out my fork and playing around with it before merging. I tried to check all the pages I could find to make sure they looked alright, but there's always a chance I missed something.

Also I added slightly more side padding to the `main` element on mobile, but that was purely subjective on my part.

Here is what the latest article looks like on 599px width right now:
<img width="600" alt="Screenshot 2025-04-07 at 8 27 40 AM" src="https://github.com/user-attachments/assets/88b7af22-9d36-4c80-9ade-9ab934a0bf09" />

And here is what it would look like at 599px after my changes:
<img width="596" alt="Screenshot 2025-04-07 at 8 27 57 AM" src="https://github.com/user-attachments/assets/8ff36bf8-85a3-4167-9617-61116ceb31db" />
